### PR TITLE
Add Github Actions for Pull Requests

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+    status:
+        patch:
+            default:
+                target: '100'
+        project:
+            default:
+                target: '88'

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+source =
+    amazon_transcribe
+
+[report]
+exclude_lines =
+    raise NotImplementedError

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+    push:
+        branches: develop
+    pull_request:
+        branches: develop
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v1
+      - name: Set Up Python - ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install tox
+        run: |
+          python${{ matrix.python-version }} -m pip install --upgrade tox
+      - name: Run tests
+        run: |
+          tox -e py
+      - name: Upload coverage
+        if: matrix.python-version == 3.7
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          yml: ./codecov.yml
+          fail_ci_if_error: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: Lint
+
+on:
+    push:
+        branches: develop
+    pull_request:
+        branches: develop
+
+jobs:
+  black-and-flake8:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v1
+      - name: Set Up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install tox
+        run: |
+          python3.7 -m pip install tox
+      - name: Run linting
+        run: |
+            tox -e lint

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,25 @@
+name: Type Check
+
+on:
+    push:
+        branches: develop
+    pull_request:
+        branches: develop
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v1
+      - name: Set Up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install tox
+        run: |
+          python3.7 -m pip install tox
+      - name: Run type checks
+        run: |
+            tox -e type

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+black==19.10b0
+flake8<3.9
+mypy<1.0
+pytest<5.5
+pytest-asyncio<0.15.0
+pytest-cov<2.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-pytest<5.5
-pytest-asyncio<0.15.0
-mypy<1.0
-black==19.10b0

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,7 @@ universal = 1
 [metadata]
 requires-dist =
     # TODO
+
+[flake8]
+# We ignore E203, E501 for this project due to black
+ignore = E203,E501

--- a/tests/functional/test_httpsession.py
+++ b/tests/functional/test_httpsession.py
@@ -1,5 +1,5 @@
 import asyncio
-import mock
+import unittest.mock as mock
 import pytest
 
 from io import BytesIO

--- a/tests/functional/test_model.py
+++ b/tests/functional/test_model.py
@@ -1,6 +1,5 @@
 import pytest
 
-from mock import Mock
 from amazon_transcribe.auth import StaticCredentialResolver
 from amazon_transcribe.model import AudioStream
 from amazon_transcribe.serialize import AudioEventSerializer

--- a/tests/unit/test_deserialize.py
+++ b/tests/unit/test_deserialize.py
@@ -1,6 +1,6 @@
 import json
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 
 from amazon_transcribe.request import HeadersDict
 from amazon_transcribe.response import Response

--- a/tests/unit/test_eventstream.py
+++ b/tests/unit/test_eventstream.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 """Unit tests for the binary event stream decoder. """
 
-from mock import Mock
+from unittest.mock import Mock
 import pytest
 import uuid
 import datetime

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,28 @@ envlist = py36,py37,py38
 skipsdist = True
 
 [testenv]
+deps =
+    -r requirements-dev.txt
+    -e .
 commands =
-    pytest tests
-    mypy transcribe --ignore-missing-imports
-    black --check transcribe
+    pytest --cov-config=.coveragerc --cov=./ --cov-report=xml tests/functional tests/unit
+
+[testenv:lint]
+deps =
+    -r requirements-dev.txt
+commands =
+    black --check amazon_transcribe tests
+    flake8 amazon_transcribe
+
+[testenv:type]
+deps =
+    -r requirements-dev.txt
+commands =
+    mypy amazon_transcribe --ignore-missing-imports
+
+[testenv:full_tests]
+deps =
+    -r requirements-dev.txt
+    -e .
+commands =
+    pytest --cov-config=.coveragerc --cov=./ --cov-report=xml tests


### PR DESCRIPTION
This PR will add some basic Github Actions for our pull requests. Three workflows run that will:

1. Run our functional and unit tests on Python 3.{6-8}
1. Lint the Pull Request and existing code base with `black` and `flake8`
1. Run type checking with `mypy`
    * This currently ignores errors from `awscrt` and doesn't enforce `--strict`. That will be handled in a future CR.