### PR TITLE
Added vocab_filter_name to start_stream_transcription.

### DIFF
--- a/amazon_transcribe/client.py
+++ b/amazon_transcribe/client.py
@@ -76,6 +76,7 @@ class TranscribeStreamingClient:
         vocabulary_name: Optional[str] = None,
         session_id: Optional[str] = None,
         vocab_filter_method: Optional[str] = None,
+        vocab_filter_name: Optional[str] = None,
     ) -> StartStreamTranscriptionEventStream:
         """Coordinate transcription settings and start stream.
 
@@ -107,6 +108,8 @@ class TranscribeStreamingClient:
         :param vocab_filter_method:
             The manner in which you use your vocabulary filter to filter words in
             your transcript. See Transcribe Streaming API docs for more info.
+        :param vocab_filter_name:
+            The name of the vocabulary filter you've created that is unique to your AWS account.
         """
         transcribe_streaming_request = StartStreamTranscriptionRequest(
             language_code,
@@ -115,6 +118,7 @@ class TranscribeStreamingClient:
             vocabulary_name,
             session_id,
             vocab_filter_method,
+            vocab_filter_name,
         )
         endpoint = await self._endpoint_resolver.resolve(self.region)
         self._serializer: Serializer = TranscribeStreamingRequestSerializer(

--- a/amazon_transcribe/model.py
+++ b/amazon_transcribe/model.py
@@ -163,6 +163,9 @@ class StartStreamTranscriptionRequest:
     :param vocab_filter_method:
         The manner in which you use your vocabulary filter to filter words in
         your transcript.
+
+    :param vocab_filter_name:
+        The name of the vocabulary filter you've created that is unique to your AWS account.
     """
 
     def __init__(
@@ -173,6 +176,7 @@ class StartStreamTranscriptionRequest:
         vocabulary_name=None,
         session_id=None,
         vocab_filter_method=None,
+        vocab_filter_name=None,
     ):
 
         self.language_code: Optional[str] = language_code
@@ -181,6 +185,7 @@ class StartStreamTranscriptionRequest:
         self.vocabulary_name: Optional[str] = vocabulary_name
         self.session_id: Optional[str] = session_id
         self.vocab_filter_method: Optional[str] = vocab_filter_method
+        self.vocab_filter_name: Optional[str] = vocab_filter_name
 
 
 class StartStreamTranscriptionResponse:

--- a/amazon_transcribe/serialize.py
+++ b/amazon_transcribe/serialize.py
@@ -60,6 +60,7 @@ class TranscribeStreamingRequestSerializer(Serializer):
             "x-amzn-transcribe-vocabulary-name": self.request_shape.vocabulary_name,
             "x-amzn-transcribe-session-id": self.request_shape.session_id,
             "x-amzn-transcribe-vocabulary-filter-method": self.request_shape.vocab_filter_method,
+            "x-amzn-transcribe-vocabulary-filter-name": self.request_shape.vocab_filter_name,
         }
         _add_required_headers(self.endpoint, headers)
 


### PR DESCRIPTION
*Issue #, if available:* awslabs/amazon-transcribe-streaming-sdk#8

*Description of changes:* Added `vocab_filter_name` to `start_stream_transcription` per documentation at https://docs.aws.amazon.com/transcribe/latest/dg/API_streaming_StartStreamTranscription.html#API_streaming_StartStreamTranscription_RequestSyntax.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
