### PR TITLE
Upgrade AWS CRT to 0.11.11

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+dev
+---
+
+* The required version of awscrt has been upgraded to 0.11.11
+
 0.2.0 (2020-11-13)
 -----------------
 

--- a/amazon_transcribe/signer.py
+++ b/amazon_transcribe/signer.py
@@ -20,7 +20,7 @@ from awscrt.auth import (
     AwsSigningAlgorithm,
     AwsSigningConfig,
     AwsSignatureType,
-    AwsSignedBodyValueType,
+    AwsSignedBodyValue,
     AwsSignedBodyHeaderType,
     aws_sign_request,
 )
@@ -58,7 +58,7 @@ class RequestSigner:
             credentials_provider=credential_provider,
             region=self.region,
             service=self.service_name,
-            signed_body_value_type=AwsSignedBodyValueType.EMPTY,
+            signed_body_value=AwsSignedBodyValue.UNSIGNED_PAYLOAD,
             signed_body_header_type=AwsSignedBodyHeaderType.NONE,
         )
         crt_request = _convert_request(request)

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal = 1
 
 [metadata]
 requires_dist =
-    # TODO
+    awscrt==0.11.11
 
 [flake8]
 # We ignore E203, E501 for this project due to black

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def find_version(*file_paths):
     raise RuntimeError("Unable to find version string.")
 
 
-requires = ["awscrt==0.6.1"]
+requires = ["awscrt==0.11.11"]
 
 setup(
     name="amazon-transcribe",


### PR DESCRIPTION
This patch will update the code to work with awscrt 0.11.10. This should resolve build issues on Python 3.9 and bring some of the newer improvements in the CRT into the Amazon Transcribe Streaming SDK.

This should resolve #20 and #22.