### PR TITLE
Fix signature mismatches

### DIFF
--- a/amazon_transcribe/signer.py
+++ b/amazon_transcribe/signer.py
@@ -58,7 +58,7 @@ class RequestSigner:
             credentials_provider=credential_provider,
             region=self.region,
             service=self.service_name,
-            signed_body_value=AwsSignedBodyValue.UNSIGNED_PAYLOAD,
+            signed_body_value=AwsSignedBodyValue.EMPTY_SHA256,
             signed_body_header_type=AwsSignedBodyHeaderType.NONE,
         )
         crt_request = _convert_request(request)

--- a/amazon_transcribe/structures.py
+++ b/amazon_transcribe/structures.py
@@ -23,6 +23,8 @@ if TYPE_CHECKING:
 
 
 class BufferableByteStream(BufferedIOBase):
+    """ BufferableByteStream will always be in non-blocking mode """
+
     def __init__(self):
         self._byte_chunks: list = []
         self.__done: bool = False
@@ -30,9 +32,7 @@ class BufferableByteStream(BufferedIOBase):
 
     def read(self, size=-1) -> Optional[bytes]:  # type: ignore
         if len(self._byte_chunks) < 1 and not self.__done:
-            # This behavior is a quirk of CRT where we have
-            # an open stream but no data to be read.
-            return None
+            raise BlockingIOError("read")
         elif (self.__done and not self._byte_chunks) or self.closed:
             return b""
 
@@ -65,7 +65,7 @@ class BufferableByteStream(BufferedIOBase):
             data = self.read(len(b))
 
         if data is None:
-            return None
+            raise BlockingIOError("readinto")
 
         n = len(data)
 

--- a/tests/functional/test_structures.py
+++ b/tests/functional/test_structures.py
@@ -43,7 +43,8 @@ class TestBufferableByteStream:
     def test_byte_stream_write_empty_bytes(self, byte_stream):
         size = byte_stream.write(b"")
         assert size == 0
-        assert byte_stream.read() is None
+        with pytest.raises(BlockingIOError):
+            byte_stream.read()
 
     def test_byte_stream_read(self, byte_stream):
         byte_stream.write(b"test")
@@ -56,7 +57,8 @@ class TestBufferableByteStream:
         assert byte_stream.read(100) == b"te chunk"
 
     def test_byte_stream_read_empty(self, byte_stream):
-        assert byte_stream.read() is None
+        with pytest.raises(BlockingIOError):
+            byte_stream.read()
 
     def test_byte_stream_read_closed(self, byte_stream):
         byte_stream.close()
@@ -99,6 +101,7 @@ class TestBufferableByteStream:
         assert byte_stream.read() == b"test"
         byte_stream.write(b"chunk")
         assert byte_stream.read() == b"chunk"
-        assert byte_stream.read() is None
+        with pytest.raises(BlockingIOError):
+            byte_stream.read()
         byte_stream.write(b"next")
         assert byte_stream.read() == b"next"


### PR DESCRIPTION
Fix signing issues with CRT changes around empty bodies. This will ensure integration tests function properly with the service again.