### PR TITLE
Added confidence score to items

### DIFF
--- a/amazon_transcribe/deserialize.py
+++ b/amazon_transcribe/deserialize.py
@@ -195,6 +195,7 @@ class TranscribeStreamingEventParser:
             content=current_node.get("Content"),
             vocabulary_filter_match=current_node.get("VocabularyFilterMatch"),
             speaker=current_node.get("Speaker"),
+            confidence=current_node.get("Confidence"),
         )
 
     def _parse_event_exception(self, raw_event) -> ServiceException:

--- a/amazon_transcribe/model.py
+++ b/amazon_transcribe/model.py
@@ -96,6 +96,7 @@ class Item:
         content: Optional[str] = None,
         vocabulary_filter_match: Optional[bool] = None,
         speaker: Optional[str] = None,
+        confidence: Optional[float] = None,
     ):
         self.start_time = start_time
         self.end_time = end_time
@@ -103,6 +104,7 @@ class Item:
         self.content = content
         self.vocabulary_filter_match = vocabulary_filter_match
         self.speaker = speaker
+        self.confidence = confidence
 
 
 class Result:

--- a/amazon_transcribe/model.py
+++ b/amazon_transcribe/model.py
@@ -86,6 +86,10 @@ class Item:
     :param speaker:
         If speaker identification is enabled, shows the speakers identified
         in the real-time stream.
+
+    :param confidence:
+        A value between 0 and 1 for an item that is a confidence score that
+        Amazon Transcribe assigns to each word or phrase that it transcribes.
     """
 
     def __init__(

--- a/tests/unit/test_deserialize.py
+++ b/tests/unit/test_deserialize.py
@@ -149,6 +149,7 @@ def test_parses_transcript_event(event_parser):
                                     "StartTime": 0.11,
                                     "Type": "pronunciation",
                                     "VocabularyFilterMatch": False,
+                                    "Confidence": 0.82,
                                 },
                                 {
                                     "Content": "Chief",
@@ -156,6 +157,7 @@ def test_parses_transcript_event(event_parser):
                                     "StartTime": 0.55,
                                     "Type": "pronunciation",
                                     "VocabularyFilterMatch": False,
+                                    "Confidence": 0.9,
                                 },
                             ],
                             "Transcript": "Wanted Chief",
@@ -186,12 +188,14 @@ def test_parses_transcript_event(event_parser):
     assert item_one.end_time == 0.45
     assert item_one.item_type == "pronunciation"
     assert item_one.vocabulary_filter_match == False
+    assert item_one.confidence == 0.82
     item_two = result.alternatives[0].items[1]
     assert item_two.content == "Chief"
     assert item_two.start_time == 0.55
     assert item_two.end_time == 0.86
     assert item_two.item_type == "pronunciation"
     assert item_two.vocabulary_filter_match == False
+    assert item_two.confidence == 0.9
 
 
 def test_parses_known_exception(event_parser):


### PR DESCRIPTION
*Description of changes:* Added `confidence` to `Item` class per documentation at [StartStreamTranscription_ResponseSyntax](https://docs.aws.amazon.com/transcribe/latest/dg/API_streaming_StartStreamTranscription.html#API_streaming_StartStreamTranscription_ResponseSyntax) and [Item](https://docs.aws.amazon.com/transcribe/latest/dg/API_streaming_Item.html).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
