### PR TITLE
Update Amazon Transcribe model changes

### DIFF
--- a/amazon_transcribe/deserialize.py
+++ b/amazon_transcribe/deserialize.py
@@ -108,6 +108,12 @@ class TranscribeStreamingResponseParser:
         media_sample_rate_hz = self._raw_value_to_int(
             headers.get("x-amzn-transcribe-sample-rate")
         )
+        enable_partial_results_stabilization = self._raw_value_to_bool(
+            headers.get("x-amzn-transcribe-enable-partial-results-stabilization")
+        )
+        partial_results_stability = headers.get(
+            "x-amzn-transcribe-partial-results-stability"
+        )
 
         transcript_result_stream = TranscriptResultStream(
             body_stream, TranscribeStreamingEventParser()
@@ -126,6 +132,8 @@ class TranscribeStreamingResponseParser:
             show_speaker_label=show_speaker_label,
             enable_channel_identification=enable_channel_identification,
             number_of_channels=number_of_channels,
+            enable_partial_results_stabilization=enable_partial_results_stabilization,
+            partial_results_stability=partial_results_stability,
         )
         return parsed_response
 
@@ -196,6 +204,7 @@ class TranscribeStreamingEventParser:
             vocabulary_filter_match=current_node.get("VocabularyFilterMatch"),
             speaker=current_node.get("Speaker"),
             confidence=current_node.get("Confidence"),
+            stable=current_node.get("Stable"),
         )
 
     def _parse_event_exception(self, raw_event) -> ServiceException:

--- a/amazon_transcribe/model.py
+++ b/amazon_transcribe/model.py
@@ -32,8 +32,8 @@ class AudioEvent(BaseEvent):
     """Provides a wrapper for the audio chunks that you are sending.
 
     :param audio_chunk:
-        A blob of audio from your application. You audio stream
-        consists of one or more audio events.
+        A blob of audio from your application. You audio stream consists
+        of one or more audio events. The maximum audio chunk size is 32 KB.
     """
 
     def __init__(self, audio_chunk: Optional[bytes]):
@@ -57,13 +57,14 @@ class AudioStream(BaseStream):
         """Enqueue audio bytes to be sent for transcription.
 
         :param audio_chunk: byte-string chunk of audio input.
+            The maximum audio chunk size is 32 KB.
         """
         audio_event = AudioEvent(audio_chunk)
         await super().send_event(audio_event)
 
 
 class Item:
-    """A word or phrase transcribed from the input audio.
+    """A word, phrase, or punctuation mark that is transcribed from the input audio.
 
     :param start_time:
         The offset from the beginning of the audio stream to the beginning
@@ -90,6 +91,11 @@ class Item:
     :param confidence:
         A value between 0 and 1 for an item that is a confidence score that
         Amazon Transcribe assigns to each word or phrase that it transcribes.
+
+    :param stable:
+       If partial result stabilization has been enabled, indicates whether the
+       word or phrase in the item is stable. If Stable is true,
+       the result is stable.
     """
 
     def __init__(
@@ -101,6 +107,7 @@ class Item:
         vocabulary_filter_match: Optional[bool] = None,
         speaker: Optional[str] = None,
         confidence: Optional[float] = None,
+        stable: Optional[bool] = None,
     ):
         self.start_time = start_time
         self.end_time = end_time
@@ -109,6 +116,7 @@ class Item:
         self.vocabulary_filter_match = vocabulary_filter_match
         self.speaker = speaker
         self.confidence = confidence
+        self.stable = stable
 
 
 class Result:
@@ -203,6 +211,19 @@ class StartStreamTranscriptionRequest:
 
     :param number_of_channels:
         The number of channels that are in your audio stream.
+
+    :param enable_partial_results_stabilization:
+        When true, instructs Amazon Transcribe to present transcription results
+        that have the partial results stabilized. Normally, any word or phrase
+        from one partial result can change in a subsequent partial result. With
+        partial results stabilization enabled, only the last few words of one
+        partial result can change in another partial result.
+
+    :param partial_results_stability:
+        You can use this field to set the stability level of the transcription
+        results. A higher stability level means that the transcription results
+        are less likely to change. Higher stability levels can come with lower
+        overall transcription accuracy.
     """
 
     def __init__(
@@ -217,6 +238,8 @@ class StartStreamTranscriptionRequest:
         show_speaker_label=None,
         enable_channel_identification=None,
         number_of_channels=None,
+        enable_partial_results_stabilization=None,
+        partial_results_stability=None,
     ):
 
         self.language_code: Optional[str] = language_code
@@ -231,6 +254,10 @@ class StartStreamTranscriptionRequest:
             bool
         ] = enable_channel_identification
         self.number_of_channels: Optional[int] = number_of_channels
+        self.enable_partial_results_stabilization: Optional[
+            bool
+        ] = enable_partial_results_stabilization
+        self.partial_results_stability: Optional[str] = partial_results_stability
 
 
 class StartStreamTranscriptionResponse:
@@ -272,6 +299,14 @@ class StartStreamTranscriptionResponse:
 
     :param number_of_channels:
         The number of channels identified in the stream.
+
+    :param enable_partial_results_stabilization:
+        Shows whether partial results stabilization has been enabled in the
+        stream.
+
+    :param partial_results_stability:
+        If partial results stabilization has been enabled in the stream,
+        shows the stability level.
     """
 
     def __init__(
@@ -288,6 +323,8 @@ class StartStreamTranscriptionResponse:
         show_speaker_label=None,
         enable_channel_identification=None,
         number_of_channels=None,
+        enable_partial_results_stabilization=None,
+        partial_results_stability=None,
     ):
         self.request_id: Optional[str] = request_id
         self.language_code: Optional[str] = language_code
@@ -303,6 +340,10 @@ class StartStreamTranscriptionResponse:
             bool
         ] = enable_channel_identification
         self.number_of_channels: Optional[int] = number_of_channels
+        self.enable_partial_results_stabilization: Optional[
+            bool
+        ] = enable_partial_results_stabilization
+        self.partial_results_stability: Optional[str] = partial_results_stability
 
 
 class Transcript:

--- a/amazon_transcribe/serialize.py
+++ b/amazon_transcribe/serialize.py
@@ -104,6 +104,17 @@ class TranscribeStreamingSerializer:
                 "number-of-channels", request_shape.number_of_channels,
             )
         )
+        headers.update(
+            self._serialize_bool_header(
+                "enable-partial-results-stabilization",
+                request_shape.enable_partial_results_stabilization,
+            )
+        )
+        headers.update(
+            self._serialize_str_header(
+                "partial-results-stability", request_shape.partial_results_stability,
+            )
+        )
 
         _add_required_headers(endpoint, headers)
 

--- a/tests/unit/test_deserialize.py
+++ b/tests/unit/test_deserialize.py
@@ -39,6 +39,8 @@ def test_parse_start_stream_transcription_response_basic(parser):
             "x-amzn-transcribe-show-speaker-label": "true",
             "x-amzn-transcribe-enable-channel-identification": "false",
             "x-amzn-transcribe-number-of-channels": "0",
+            "x-amzn-transcribe-enable-partial-results-stabilization": "true",
+            "x-amzn-transcribe-partial-results-stability": "high",
         }
     )
     parsed = parser.parse_start_stream_transcription_response(response, None)
@@ -50,25 +52,29 @@ def test_parse_start_stream_transcription_response_basic(parser):
     assert parsed.session_id == "foo_id"
     assert parsed.vocab_filter_name == "foo_filter_name"
     assert parsed.vocab_filter_method == "foo_filter_method"
-    assert parsed.show_speaker_label == True
-    assert parsed.enable_channel_identification == False
+    assert parsed.show_speaker_label is True
+    assert parsed.enable_channel_identification is False
     assert parsed.number_of_channels == 0
+    assert parsed.enable_partial_results_stabilization is True
+    assert parsed.partial_results_stability == "high"
 
 
 def test_parse_start_stream_transcription_response_missing_fields(parser):
     response = Response(headers={})
     parsed = parser.parse_start_stream_transcription_response(response, None)
-    assert parsed.request_id == None
-    assert parsed.language_code == None
-    assert parsed.media_sample_rate_hz == None
-    assert parsed.media_encoding == None
-    assert parsed.vocabulary_name == None
-    assert parsed.session_id == None
-    assert parsed.vocab_filter_name == None
-    assert parsed.vocab_filter_method == None
-    assert parsed.show_speaker_label == None
-    assert parsed.enable_channel_identification == None
-    assert parsed.number_of_channels == None
+    assert parsed.request_id is None
+    assert parsed.language_code is None
+    assert parsed.media_sample_rate_hz is None
+    assert parsed.media_encoding is None
+    assert parsed.vocabulary_name is None
+    assert parsed.session_id is None
+    assert parsed.vocab_filter_name is None
+    assert parsed.vocab_filter_method is None
+    assert parsed.show_speaker_label is None
+    assert parsed.enable_channel_identification is None
+    assert parsed.number_of_channels is None
+    assert parsed.enable_partial_results_stabilization is None
+    assert parsed.partial_results_stability is None
 
 
 @pytest.mark.parametrize(
@@ -150,6 +156,7 @@ def test_parses_transcript_event(event_parser):
                                     "Type": "pronunciation",
                                     "VocabularyFilterMatch": False,
                                     "Confidence": 0.82,
+                                    "Stable": False,
                                 },
                                 {
                                     "Content": "Chief",
@@ -158,6 +165,7 @@ def test_parses_transcript_event(event_parser):
                                     "Type": "pronunciation",
                                     "VocabularyFilterMatch": False,
                                     "Confidence": 0.9,
+                                    "Stable": True,
                                 },
                             ],
                             "Transcript": "Wanted Chief",
@@ -187,15 +195,17 @@ def test_parses_transcript_event(event_parser):
     assert item_one.start_time == 0.11
     assert item_one.end_time == 0.45
     assert item_one.item_type == "pronunciation"
-    assert item_one.vocabulary_filter_match == False
+    assert item_one.vocabulary_filter_match is False
     assert item_one.confidence == 0.82
+    assert item_one.stable is False
     item_two = result.alternatives[0].items[1]
     assert item_two.content == "Chief"
     assert item_two.start_time == 0.55
     assert item_two.end_time == 0.86
     assert item_two.item_type == "pronunciation"
-    assert item_two.vocabulary_filter_match == False
+    assert item_two.vocabulary_filter_match is False
     assert item_two.confidence == 0.9
+    assert item_two.stable is True
 
 
 def test_parses_known_exception(event_parser):


### PR DESCRIPTION
This PR will bring in many of the recent model changes that are missing from Transcribe. This will add support for Transcribe stability features with the addition of `enable_partial_results_stabilization`, `partial_results_stability`, and `Item.stable`.