### PR TITLE
v0.5.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,19 @@
 Changes
 =======
 
+0.5.0 (2021-08-12)
+------------------
+
+* The required version of awscrt has been upgraded to 0.11.24 (#47)
+
+* Added official support for Python 3.9 (#46)
+
+* Added `confidence` score to the `Item` class. (#45)
+
+* Added stabilization features with `enable_partial_results_stabilization`,
+  `partial_results_stability` and `Item.stable`. (#48)
+
+
 0.4.0 (2021-05-11)
 ------------------
 

--- a/amazon_transcribe/__init__.py
+++ b/amazon_transcribe/__init__.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 from awscrt.io import ClientBootstrap, DefaultHostResolver, EventLoopGroup
 


### PR DESCRIPTION
0.5.0 (2021-08-12)
------------------

* The required version of awscrt has been upgraded to 0.11.24 (#47)

* Added official support for Python 3.9 (#46)

* Added `confidence` score to the `Item` class. (#45)

* Added stabilization features with `enable_partial_results_stabilization`,
  `partial_results_stability` and `Item.stable`. (#48)