### PR TITLE
Add Python 3.10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v1
       - name: Set Up Python - ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tox

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 Changes
 =======
 
+Next (TBD)
+------------------
+
+* The required version of awscrt has been upgraded to 0.12.5 (#58)
+
+* Added official support for Python 3.10 (#58)
+
+* Allow partial results stabilization options (#54)
+
+
 0.5.0 (2021-08-12)
 ------------------
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ black==19.10b0
 flake8<3.9
 mypy<1.0
 pre-commit>=2.15.0
-pytest<5.5
-pytest-asyncio<0.15.0
-pytest-cov<2.11
+pytest<6.3
+pytest-asyncio<0.16.0
+pytest-cov<2.13
 tox>2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal = 0
 
 [metadata]
 requires_dist =
-    awscrt==0.11.24
+    awscrt==0.12.5
 
 [flake8]
 # We ignore E203, E501 for this project due to black

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def find_version(*file_paths):
     raise RuntimeError("Unable to find version string.")
 
 
-requires = ["awscrt==0.11.24"]
+requires = ["awscrt==0.12.5"]
 
 setup(
     name="amazon-transcribe",
@@ -50,5 +50,6 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39
+envlist = py36,py37,py38,py39,py310
 
 skipsdist = True
 


### PR DESCRIPTION
Updates the CRT version to match the latest version of botocore:

https://github.com/boto/botocore/pull/2523

Ran the integ tests locally on Python 3.10 as well.