### PR TITLE
v0.5.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changes
 =======
 
-Next (TBD)
+0.5.1 (2021-10-18)
 ------------------
 
 * The required version of awscrt has been upgraded to 0.12.5 (#58)

--- a/amazon_transcribe/__init__.py
+++ b/amazon_transcribe/__init__.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 from awscrt.io import ClientBootstrap, DefaultHostResolver, EventLoopGroup
 


### PR DESCRIPTION
Stages the v0.5.1 release.

Changes included in this release:

* The required version of `awscrt` has been upgraded to 0.12.5 (#58)

* Added official support for Python 3.10 (#58)

* Allow partial results stabilization options (#54)