### PR TITLE
v0.5.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changes
 =======
 
+0.5.2 (2022-03-15)
+------------------
+
+* The required version of awscrt has been upgraded to 0.13.5 (#65)
+
+* NOTICE: This will be the last version with Python 3.6 support
+
+
 0.5.1 (2021-10-18)
 ------------------
 

--- a/amazon_transcribe/__init__.py
+++ b/amazon_transcribe/__init__.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 from awscrt.io import ClientBootstrap, DefaultHostResolver, EventLoopGroup
 


### PR DESCRIPTION
Stages the `0.5.2` release.

* The required version of awscrt has been upgraded to 0.13.5 (#65)

* NOTICE: This will be the last version with Python 3.6 support