### PR TITLE
Update CRT version to 0.13.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal = 0
 
 [metadata]
 requires_dist =
-    awscrt==0.13.5
+    awscrt~=0.13.8
 
 [flake8]
 # We ignore E203, E501 for this project due to black

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def find_version(*file_paths):
     raise RuntimeError("Unable to find version string.")
 
 
-requires = ["awscrt==0.13.5"]
+requires = ["awscrt~=0.13.8"]
 
 setup(
     name="amazon-transcribe",


### PR DESCRIPTION
Updating version range for awscrt to `~=0.13.8`. This will reduce the number of releases required for CRT updates by treating the dependency as `awscrt==0.13.*,>=0.13.8`. This update also fixes rare signing failures on Windows.
