### PR TITLE
v0.6.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,14 @@
 Changes
 =======
 
-0.6.0 (2022-04-05)
+0.6.0 (2022-04-06)
 ------------------
 
-* Officially drop support for Python 3.6
+* Officially drop support for Python 3.6 (#69)
+
+* The required version of awscrt has been upgraded to ~=0.13.8 (#67)
+
+* Added support for `language_model_name` for both requests and responses. (#70)
 
 
 0.5.2 (2022-03-15)

--- a/amazon_transcribe/__init__.py
+++ b/amazon_transcribe/__init__.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 
-__version__ = "0.5.2"
+__version__ = "0.6.0"
 
 from awscrt.io import ClientBootstrap, DefaultHostResolver, EventLoopGroup
 


### PR DESCRIPTION
# v0.6.0

* Officially drop support for Python 3.6 (#69)

* The required version of awscrt has been upgraded to ~=0.13.8 (#67)

* Added support for `language_model_name` for both requests and responses. (#70)