### PR TITLE
Stop creating a new EventLoopGroup for each AWSCRTEventLoop instance

### DIFF
--- a/amazon_transcribe/__init__.py
+++ b/amazon_transcribe/__init__.py
@@ -14,17 +14,9 @@
 
 __version__ = "0.6.0"
 
-from awscrt.io import ClientBootstrap, DefaultHostResolver, EventLoopGroup
+from awscrt.io import ClientBootstrap
 
 
 class AWSCRTEventLoop:
     def __init__(self):
-        self.bootstrap = self._initialize_default_loop()
-
-    def _initialize_default_loop(self):
-        event_loop_group = EventLoopGroup(1)
-        host_resolver = DefaultHostResolver(event_loop_group)
-        return ClientBootstrap(
-            event_loop_group,
-            host_resolver,
-        )
+        self.bootstrap = ClientBootstrap.get_or_create_static_default()


### PR DESCRIPTION
*Issue #, if available:* #78

*Description of changes:*
* Changed `AWSCRTEventLoop` to  use `ClientBootstrap.get_or_create_static_default()` instead of creating a new `EventLoopGroup(1)` and a new `DefaultHostResolver()` for each new instance.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
