### PR TITLE
Update awscrt to ~=0.14.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal = 0
 
 [metadata]
 requires_dist =
-    awscrt~=0.13.8
+    awscrt~=0.14.0
 
 [flake8]
 # We ignore E203, E501 for this project due to black


### PR DESCRIPTION
This PR will update our usage of the AWS CRT to 0.14.x in preparation for our next release.