### PR TITLE
handle_events must return the sub-handler results

### DIFF
--- a/amazon_transcribe/handlers.py
+++ b/amazon_transcribe/handlers.py
@@ -25,7 +25,7 @@ class TranscriptResultStreamHandler:
         """
         async for event in self._transcript_result_stream:
             if isinstance(event, TranscriptEvent):
-                await self.handle_transcript_event(event)
+                return await self.handle_transcript_event(event)
 
     async def handle_transcript_event(self, transcript_event: TranscriptEvent):
         """Specific handling for TranscriptionEvent responses from Amazon Transcribe.


### PR DESCRIPTION
*Issue #, if available:*
When implementing handle_transcript_event() method, one might need to return values from there, but the upper class method handle_events() doesn't return anything, which leads to the lost of the returned value in the implemented method. Thus any calls to handle_events() returns None.
*Description of changes:*
Added the return clause to the handle_transcript_event() call inside handle_events()

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
