### PR TITLE
v0.6.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changes
 =======
 
+0.6.2 (2023-06-14)
+------------------
+
+* The required version of awscrt has been upgraded to ~=0.16.0 (#93)
+
+
 0.6.1 (2022-10-04)
 ------------------
 

--- a/amazon_transcribe/__init__.py
+++ b/amazon_transcribe/__init__.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 from awscrt.io import ClientBootstrap
 


### PR DESCRIPTION
0.6.2 (2023-06-14)
------------------

* The required version of awscrt has been upgraded to ~=0.16.0 (#93)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
