### PR TITLE
Add headers for multiple language identification

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,6 @@
 coverage:
+    ignore:
+        - "tests/*"
     status:
         patch:
             default:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,10 @@ jobs:
           tox -e py
       - name: Upload coverage
         if: matrix.python-version == 3.11
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
-          yml: ./codecov.yml
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - name: Checkout Repository
@@ -29,7 +29,7 @@ jobs:
         run: |
           tox -e py
       - name: Upload coverage
-        if: matrix.python-version == 3.7
+        if: matrix.python-version == 3.11
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,13 +8,13 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Run pre-commit
       uses: pre-commit/action@v2.0.0

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -13,13 +13,13 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v1
-      - name: Set Up Python 3.7
+      - name: Set Up Python 3.11
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.11
       - name: Install tox
         run: |
-          python3.7 -m pip install tox
+          python3.11 -m pip install tox
       - name: Run type checks
         run: |
             tox -e type

--- a/amazon_transcribe/client.py
+++ b/amazon_transcribe/client.py
@@ -84,6 +84,8 @@ class TranscribeStreamingClient:
         enable_partial_results_stabilization: Optional[bool] = None,
         partial_results_stability: Optional[str] = None,
         language_model_name: Optional[str] = None,
+        identify_multiple_languages=False,
+        language_options=None
     ) -> StartStreamTranscriptionEventStream:
         """Coordinate transcription settings and start stream.
 
@@ -100,7 +102,8 @@ class TranscribeStreamingClient:
         than 5 minutes.
 
         :param language_code:
-            Indicates the source language used in the input audio stream.
+            Indicates the source language used in the input audio stream. Set to
+            None if identify_multiple_languages is set to True
         :param media_sample_rate_hz:
             The sample rate, in Hertz, of the input audio. We suggest that you
             use 8000 Hz for low quality audio and 16000 Hz for high quality audio.
@@ -144,6 +147,15 @@ class TranscribeStreamingClient:
             overall transcription accuracy. Defaults to "high" if not set explicitly.
         :param language_model_name:
             The name of the language model you want to use.
+        :param identify_multiple_languages:
+            If true, all languages spoken in the stream are identified. A multilingual
+            transcripts is created your transcript using each identified language.
+            You must also provide at least two language_options and set
+            language_code to None
+        :param language_options:
+            A list of possible language to use when identify_multiple_languages is
+            set to True. Note that not all languages supported by Transcribe are
+            supported for multiple language identification
         """
         transcribe_streaming_request = StartStreamTranscriptionRequest(
             language_code,
@@ -159,6 +171,8 @@ class TranscribeStreamingClient:
             enable_partial_results_stabilization,
             partial_results_stability,
             language_model_name,
+            identify_multiple_languages,
+            language_options
         )
         endpoint = await self._endpoint_resolver.resolve(self.region)
 

--- a/amazon_transcribe/client.py
+++ b/amazon_transcribe/client.py
@@ -84,8 +84,10 @@ class TranscribeStreamingClient:
         enable_partial_results_stabilization: Optional[bool] = None,
         partial_results_stability: Optional[str] = None,
         language_model_name: Optional[str] = None,
+        identify_language: Optional[bool] = False,
+        preferred_language: Optional[str] = None,
         identify_multiple_languages=False,
-        language_options=None
+        language_options=None,
     ) -> StartStreamTranscriptionEventStream:
         """Coordinate transcription settings and start stream.
 
@@ -147,6 +149,13 @@ class TranscribeStreamingClient:
             overall transcription accuracy. Defaults to "high" if not set explicitly.
         :param language_model_name:
             The name of the language model you want to use.
+        :param identify_language:
+            if True, the language of the stream will be automatically detected. Set
+            language_code to None and provide at least two language_options when
+            identify_language is True.
+        :param preferred_language:
+            Adding a preferred language can speed up the language identification
+            process, which is helpful for short audio clips.
         :param identify_multiple_languages:
             If true, all languages spoken in the stream are identified. A multilingual
             transcripts is created your transcript using each identified language.
@@ -171,8 +180,10 @@ class TranscribeStreamingClient:
             enable_partial_results_stabilization,
             partial_results_stability,
             language_model_name,
+            identify_language,
+            preferred_language,
             identify_multiple_languages,
-            language_options
+            language_options,
         )
         endpoint = await self._endpoint_resolver.resolve(self.region)
 

--- a/amazon_transcribe/client.py
+++ b/amazon_transcribe/client.py
@@ -14,7 +14,7 @@
 
 import re
 from binascii import unhexlify
-from typing import Optional
+from typing import Optional, List
 
 from amazon_transcribe import AWSCRTEventLoop
 from amazon_transcribe.auth import AwsCrtCredentialResolver, CredentialResolver
@@ -84,10 +84,10 @@ class TranscribeStreamingClient:
         enable_partial_results_stabilization: Optional[bool] = None,
         partial_results_stability: Optional[str] = None,
         language_model_name: Optional[str] = None,
-        identify_language: Optional[bool] = False,
+        identify_language: Optional[bool] = None,
         preferred_language: Optional[str] = None,
-        identify_multiple_languages=False,
-        language_options=None,
+        identify_multiple_languages: Optional[bool] = None,
+        language_options: Optional[List[str]] = None,
     ) -> StartStreamTranscriptionEventStream:
         """Coordinate transcription settings and start stream.
 

--- a/amazon_transcribe/client.py
+++ b/amazon_transcribe/client.py
@@ -79,6 +79,7 @@ class TranscribeStreamingClient:
         session_id: Optional[str] = None,
         vocab_filter_method: Optional[str] = None,
         vocab_filter_name: Optional[str] = None,
+        vocab_filter_names: Optional[List[str]] = None,
         show_speaker_label: Optional[bool] = None,
         enable_channel_identification: Optional[bool] = None,
         number_of_channels: Optional[int] = None,
@@ -106,7 +107,7 @@ class TranscribeStreamingClient:
 
         :param language_code:
             Indicates the source language used in the input audio stream. Set to
-            None if identify_multiple_languages is set to True
+            None if identify_languages or identify_multiple_languages is set to True
         :param media_sample_rate_hz:
             The sample rate, in Hertz, of the input audio. We suggest that you
             use 8000 Hz for low quality audio and 16000 Hz for high quality audio.
@@ -127,7 +128,11 @@ class TranscribeStreamingClient:
         :param vocab_filter_name:
             The name of the vocabulary filter you've created that is unique to
             your AWS account. Provide the name in this field to successfully
-            use it in a stream.
+            use it in a stream. Use only when identify_languages and
+            identify_multiple_languages are set to None
+        :param vocab_filter_names:
+            The name of the vocabulary filters to use for each language option. To be
+            used in conjunction with identify_languages and identify_multiple_languages
         :param show_speaker_label:
             When true, enables speaker identification in your real-time stream.
         :param enable_channel_identification:
@@ -166,9 +171,9 @@ class TranscribeStreamingClient:
             You must also provide at least two language_options and set
             language_code to None
         :param language_options:
-            A list of possible language to use when identify_multiple_languages is
-            set to True. Note that not all languages supported by Transcribe are
-            supported for multiple language identification
+            A list of possible language to use when identify_language or
+            identify_multiple_languages is set to True. Note that not all languages
+             supported by Transcribe are supported for multiple language identification
         """
         transcribe_streaming_request = StartStreamTranscriptionRequest(
             language_code,
@@ -179,6 +184,7 @@ class TranscribeStreamingClient:
             session_id,
             vocab_filter_method,
             vocab_filter_name,
+            vocab_filter_names,
             show_speaker_label,
             enable_channel_identification,
             number_of_channels,

--- a/amazon_transcribe/client.py
+++ b/amazon_transcribe/client.py
@@ -75,6 +75,7 @@ class TranscribeStreamingClient:
         media_sample_rate_hz: int,
         media_encoding: str,
         vocabulary_name: Optional[str] = None,
+        vocabulary_names: Optional[List[str]] = None,
         session_id: Optional[str] = None,
         vocab_filter_method: Optional[str] = None,
         vocab_filter_name: Optional[str] = None,
@@ -113,6 +114,9 @@ class TranscribeStreamingClient:
             The encoding used for the input audio.
         :param vocabulary_name:
             The name of the vocabulary to use when processing the transcription job.
+        :param vocabulary_names:
+            When using language identification, the name of the vocabulary to
+            use for each language option.
         :param session_id:
             A identifier for the transcription session. Use this parameter when you
             want to retry a session. If you don't provide a session ID,
@@ -171,6 +175,7 @@ class TranscribeStreamingClient:
             media_sample_rate_hz,
             media_encoding,
             vocabulary_name,
+            vocabulary_names,
             session_id,
             vocab_filter_method,
             vocab_filter_name,

--- a/amazon_transcribe/deserialize.py
+++ b/amazon_transcribe/deserialize.py
@@ -187,6 +187,7 @@ class TranscribeStreamingEventParser:
             is_partial=current_node.get("IsPartial"),
             alternatives=alternatives,
             channel_id=current_node.get("ChannelId"),
+            language_code=current_node.get("LanguageCode"),
         )
 
     def _parse_alternative_list(self, current_node: Any) -> List[Alternative]:

--- a/amazon_transcribe/model.py
+++ b/amazon_transcribe/model.py
@@ -171,7 +171,8 @@ class StartStreamTranscriptionRequest:
     """Transcription Request
 
     :param language_code:
-        Indicates the source language used in the input audio stream.
+        Indicates the source language used in the input audio stream. Set to
+        None if identify_multiple_languages is set to True
 
     :param media_sample_rate_hz:
         The sample rate, in Hertz, of the input audio. We suggest that you
@@ -226,6 +227,15 @@ class StartStreamTranscriptionRequest:
         overall transcription accuracy.
     :param language_model_name:
         The name of the language model you want to use.
+    :param identify_multiple_languages:
+        If true, all languages spoken in the stream are identified. A multilingual
+            transcripts is created your transcript using each identified language.
+            You must also provided at least two language_options and set
+            language_code to None
+    : param language_options:
+        A list of possible language to use when identify_multiple_languages is
+        set to True. Note that not all languages supported by Transcribe are
+        supported for multiple language identification
     """
 
     def __init__(
@@ -243,6 +253,8 @@ class StartStreamTranscriptionRequest:
         enable_partial_results_stabilization=None,
         partial_results_stability=None,
         language_model_name=None,
+        identify_multiple_languages=False,
+        language_options=None
     ):
 
         self.language_code: Optional[str] = language_code
@@ -262,6 +274,8 @@ class StartStreamTranscriptionRequest:
         ] = enable_partial_results_stabilization
         self.partial_results_stability: Optional[str] = partial_results_stability
         self.language_model_name: Optional[str] = language_model_name
+        self.identify_multiple_languages: Optional[bool] = identify_multiple_languages
+        self.language_options: Optional[List[str]] = language_options or []
 
 
 class StartStreamTranscriptionResponse:

--- a/amazon_transcribe/model.py
+++ b/amazon_transcribe/model.py
@@ -230,7 +230,7 @@ class StartStreamTranscriptionRequest:
     :param identify_multiple_languages:
         If true, all languages spoken in the stream are identified. A multilingual
             transcripts is created your transcript using each identified language.
-            You must also provided at least two language_options and set
+            You must also provide at least two language_options and set
             language_code to None
     : param language_options:
         A list of possible language to use when identify_multiple_languages is
@@ -253,8 +253,10 @@ class StartStreamTranscriptionRequest:
         enable_partial_results_stabilization=None,
         partial_results_stability=None,
         language_model_name=None,
+        identify_language=None,
+        preferred_language=None,
         identify_multiple_languages=False,
-        language_options=None
+        language_options=None,
     ):
 
         self.language_code: Optional[str] = language_code
@@ -274,6 +276,8 @@ class StartStreamTranscriptionRequest:
         ] = enable_partial_results_stabilization
         self.partial_results_stability: Optional[str] = partial_results_stability
         self.language_model_name: Optional[str] = language_model_name
+        self.identify_language: Optional[bool] = identify_language
+        self.preferred_language: Optional[str] = preferred_language
         self.identify_multiple_languages: Optional[bool] = identify_multiple_languages
         self.language_options: Optional[List[str]] = language_options or []
 

--- a/amazon_transcribe/model.py
+++ b/amazon_transcribe/model.py
@@ -158,6 +158,7 @@ class Result:
         is_partial: Optional[bool] = None,
         alternatives: Optional[List[Alternative]] = None,
         channel_id: Optional[str] = None,
+        language_code: Optional[str] = None,
     ):
         self.result_id = result_id
         self.start_time = start_time
@@ -165,6 +166,7 @@ class Result:
         self.is_partial = is_partial
         self.alternatives = alternatives
         self.channel_id = channel_id
+        self.language_code = language_code
 
 
 class StartStreamTranscriptionRequest:

--- a/amazon_transcribe/model.py
+++ b/amazon_transcribe/model.py
@@ -246,6 +246,7 @@ class StartStreamTranscriptionRequest:
         media_sample_rate_hz=None,
         media_encoding=None,
         vocabulary_name=None,
+        vocabulary_names=None,
         session_id=None,
         vocab_filter_method=None,
         vocab_filter_name=None,
@@ -265,6 +266,7 @@ class StartStreamTranscriptionRequest:
         self.media_sample_rate_hz: Optional[int] = media_sample_rate_hz
         self.media_encoding: Optional[str] = media_encoding
         self.vocabulary_name: Optional[str] = vocabulary_name
+        self.vocabulary_names: Optional[List[str]] = vocabulary_names
         self.session_id: Optional[str] = session_id
         self.vocab_filter_method: Optional[str] = vocab_filter_method
         self.vocab_filter_name: Optional[str] = vocab_filter_name
@@ -344,6 +346,7 @@ class StartStreamTranscriptionResponse:
         media_sample_rate_hz=None,
         media_encoding=None,
         vocabulary_name=None,
+        vocabulary_names=None,
         session_id=None,
         vocab_filter_name=None,
         vocab_filter_method=None,
@@ -359,6 +362,7 @@ class StartStreamTranscriptionResponse:
         self.media_sample_rate_hz: Optional[int] = media_sample_rate_hz
         self.media_encoding: Optional[str] = media_encoding
         self.vocabulary_name: Optional[str] = vocabulary_name
+        self.vocabulary_names: Optional[List[str]] = vocabulary_names
         self.session_id: Optional[str] = session_id
         self.transcript_result_stream: TranscriptResultStream = transcript_result_stream
         self.vocab_filter_name: Optional[str] = vocab_filter_name

--- a/amazon_transcribe/model.py
+++ b/amazon_transcribe/model.py
@@ -234,7 +234,7 @@ class StartStreamTranscriptionRequest:
             transcripts is created your transcript using each identified language.
             You must also provide at least two language_options and set
             language_code to None
-    : param language_options:
+    :param language_options:
         A list of possible language to use when identify_multiple_languages is
         set to True. Note that not all languages supported by Transcribe are
         supported for multiple language identification
@@ -250,6 +250,7 @@ class StartStreamTranscriptionRequest:
         session_id=None,
         vocab_filter_method=None,
         vocab_filter_name=None,
+        vocab_filter_names=None,
         show_speaker_label=None,
         enable_channel_identification=None,
         number_of_channels=None,
@@ -270,6 +271,7 @@ class StartStreamTranscriptionRequest:
         self.session_id: Optional[str] = session_id
         self.vocab_filter_method: Optional[str] = vocab_filter_method
         self.vocab_filter_name: Optional[str] = vocab_filter_name
+        self.vocab_filter_names: Optional[List[str]] = vocab_filter_names
         self.show_speaker_label: Optional[bool] = show_speaker_label
         self.enable_channel_identification: Optional[
             bool

--- a/amazon_transcribe/serialize.py
+++ b/amazon_transcribe/serialize.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 
-from typing import Any, Dict, Tuple, Optional
+from typing import Any, Dict, Tuple, Optional, List
 
 from amazon_transcribe.request import Request
 from amazon_transcribe.structures import BufferableByteStream
@@ -55,6 +55,12 @@ class TranscribeStreamingSerializer:
         self, header: str, value: Optional[bool]
     ) -> Dict[str, str]:
         return self._serialize_header(header, value)
+
+    def _serialize_list_header(
+        self, header: str, value: List[str]
+    ) -> Dict[str, str]:
+        languages = ",".join(value)
+        return self._serialize_str_header(header, languages)
 
     def serialize_start_stream_transcription_request(
         self, endpoint: str, request_shape: StartStreamTranscriptionRequest
@@ -127,6 +133,20 @@ class TranscribeStreamingSerializer:
             self._serialize_str_header(
                 "language-model-name",
                 request_shape.language_model_name,
+            )
+        )
+
+        headers.update(
+            self._serialize_bool_header(
+                "identify-multiple-languages",
+                request_shape.identify_multiple_languages,
+            )
+        )
+
+        headers.update(
+            self._serialize_list_header(
+                "language-options",
+                request_shape.language_options,
             )
         )
 

--- a/amazon_transcribe/serialize.py
+++ b/amazon_transcribe/serialize.py
@@ -56,9 +56,7 @@ class TranscribeStreamingSerializer:
     ) -> Dict[str, str]:
         return self._serialize_header(header, value)
 
-    def _serialize_list_header(
-        self, header: str, value: List[str]
-    ) -> Dict[str, str]:
+    def _serialize_list_header(self, header: str, value: List[str]) -> Dict[str, str]:
         languages = ",".join(value)
         return self._serialize_str_header(header, languages)
 
@@ -138,17 +136,33 @@ class TranscribeStreamingSerializer:
 
         headers.update(
             self._serialize_bool_header(
-                "identify-multiple-languages",
-                request_shape.identify_multiple_languages,
+                "identify-language",
+                request_shape.identify_language,
             )
         )
 
         headers.update(
-            self._serialize_list_header(
-                "language-options",
-                request_shape.language_options,
+            self._serialize_str_header(
+                "preferred_language",
+                request_shape.preferred_language,
             )
         )
+
+        if request_shape.identify_multiple_languages:
+            headers.update(
+                self._serialize_bool_header(
+                    "identify-multiple-languages",
+                    request_shape.identify_multiple_languages,
+                )
+            )
+
+        if request_shape.language_options:
+            headers.update(
+                self._serialize_list_header(
+                    "language-options",
+                    request_shape.language_options,
+                )
+            )
 
         _add_required_headers(endpoint, headers)
 

--- a/amazon_transcribe/serialize.py
+++ b/amazon_transcribe/serialize.py
@@ -143,7 +143,7 @@ class TranscribeStreamingSerializer:
 
         headers.update(
             self._serialize_str_header(
-                "preferred_language",
+                "preferred-language",
                 request_shape.preferred_language,
             )
         )

--- a/amazon_transcribe/serialize.py
+++ b/amazon_transcribe/serialize.py
@@ -82,6 +82,14 @@ class TranscribeStreamingSerializer:
         headers.update(
             self._serialize_str_header("vocabulary-name", request_shape.vocabulary_name)
         )
+
+        if request_shape.vocabulary_names:
+            headers.update(
+                self._serialize_list_header(
+                    "vocabulary-names",
+                    request_shape.vocabulary_names,
+                )
+            )
         headers.update(
             self._serialize_str_header("session-id", request_shape.session_id)
         )

--- a/amazon_transcribe/serialize.py
+++ b/amazon_transcribe/serialize.py
@@ -106,6 +106,19 @@ class TranscribeStreamingSerializer:
             )
         )
         headers.update(
+            self._serialize_list_header(
+                "vocabulary-filter-names",
+                request_shape.vocab_filter_names,
+            )
+        )
+        if request_shape.vocab_filter_names:
+            headers.update(
+                self._serialize_list_header(
+                    "vocabulary-filter-names",
+                    request_shape.vocab_filter_names,
+                )
+            )
+        headers.update(
             self._serialize_bool_header(
                 "show-speaker-label",
                 request_shape.show_speaker_label,

--- a/amazon_transcribe/serialize.py
+++ b/amazon_transcribe/serialize.py
@@ -105,12 +105,6 @@ class TranscribeStreamingSerializer:
                 request_shape.vocab_filter_name,
             )
         )
-        headers.update(
-            self._serialize_list_header(
-                "vocabulary-filter-names",
-                request_shape.vocab_filter_names,
-            )
-        )
         if request_shape.vocab_filter_names:
             headers.update(
                 self._serialize_list_header(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,4 +72,4 @@ pygments_style = 'sphinx'
 #html_static_path = ['_static']
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3.7', None),}
+    'python': ('https://docs.python.org/3.11', None),}

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     include_package_data=True,
     install_requires=requires,
     extras_require={},
-    python_requires=">= 3.7",
+    python_requires=">= 3.8",
     license="Apache License 2.0",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
@@ -46,9 +46,9 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/tests/functional/test_serialize.py
+++ b/tests/functional/test_serialize.py
@@ -21,9 +21,21 @@ def request_shape():
     )
 
 
+@pytest.fixture
+def multi_lid_request():
+    return StartStreamTranscriptionRequest(
+        language_code=None,
+        media_sample_rate_hz=9000,
+        media_encoding="pcm",
+        identify_multiple_languages=True,
+        language_options=["en-US", "de-DE"]
+    )
+
+
+request_serializer = TranscribeStreamingSerializer()
+
 class TestStartStreamTransactionRequest:
     def test_serialization(self, request_shape):
-        request_serializer = TranscribeStreamingSerializer()
         request = request_serializer.serialize_start_stream_transcription_request(
             endpoint="https://transcribe.aws.com",
             request_shape=request_shape,
@@ -37,12 +49,24 @@ class TestStartStreamTransactionRequest:
         assert isinstance(request.body, BufferableByteStream)
 
     def test_serialization_with_missing_endpoint(self, request_shape):
-        request_serializer = TranscribeStreamingSerializer()
         with pytest.raises(ValidationException):
             request_serializer.serialize_start_stream_transcription_request(
                 endpoint=None,
                 request_shape=request_shape,
             )
+
+
+    def test_serialization_with_multi_lid(self, multi_lid_request):
+        request = request_serializer.serialize_start_stream_transcription_request(
+            endpoint="https://transcribe.aws.com",
+            request_shape=multi_lid_request,
+        ).prepare()
+
+        assert "x-amzn-transcribe-language-code" not in request.headers
+        assert request.headers["x-amzn-transcribe-sample-rate"] == "9000"
+        assert request.headers["x-amzn-transcribe-media-encoding"] == "pcm"
+        assert request.headers["x-amzn-transcribe-identify-multiple-languages"] == "True"
+        assert request.headers["x-amzn-transcribe-language-options"] == "en-US,de-DE"
 
 
 class TestAudioEventSerializer:

--- a/tests/functional/test_serialize.py
+++ b/tests/functional/test_serialize.py
@@ -28,11 +28,12 @@ def multi_lid_request():
         media_sample_rate_hz=9000,
         media_encoding="pcm",
         identify_multiple_languages=True,
-        language_options=["en-US", "de-DE"]
+        language_options=["en-US", "de-DE"],
     )
 
 
 request_serializer = TranscribeStreamingSerializer()
+
 
 class TestStartStreamTransactionRequest:
     def test_serialization(self, request_shape):
@@ -55,7 +56,6 @@ class TestStartStreamTransactionRequest:
                 request_shape=request_shape,
             )
 
-
     def test_serialization_with_multi_lid(self, multi_lid_request):
         request = request_serializer.serialize_start_stream_transcription_request(
             endpoint="https://transcribe.aws.com",
@@ -65,7 +65,9 @@ class TestStartStreamTransactionRequest:
         assert "x-amzn-transcribe-language-code" not in request.headers
         assert request.headers["x-amzn-transcribe-sample-rate"] == "9000"
         assert request.headers["x-amzn-transcribe-media-encoding"] == "pcm"
-        assert request.headers["x-amzn-transcribe-identify-multiple-languages"] == "True"
+        assert (
+            request.headers["x-amzn-transcribe-identify-multiple-languages"] == "True"
+        )
         assert request.headers["x-amzn-transcribe-language-options"] == "en-US,de-DE"
 
 

--- a/tests/functional/test_serialize.py
+++ b/tests/functional/test_serialize.py
@@ -29,6 +29,7 @@ def multi_lid_request():
         media_encoding="pcm",
         identify_multiple_languages=True,
         vocabulary_names=["EnglishVoc", "GermanVoc"],
+        vocab_filter_names=["EVF", "GVF"],
         language_options=["en-US", "de-DE"],
     )
 
@@ -72,6 +73,7 @@ class TestStartStreamTransactionRequest:
         assert request.headers["x-amzn-transcribe-language-options"] == "en-US,de-DE"
         cv_header = "x-amzn-transcribe-vocabulary-names"
         assert request.headers[cv_header] == "EnglishVoc,GermanVoc"
+        assert request.headers["x-amzn-transcribe-vocabulary-filter-names"] == "EVF,GVF"
 
 
 class TestAudioEventSerializer:

--- a/tests/functional/test_serialize.py
+++ b/tests/functional/test_serialize.py
@@ -70,10 +70,8 @@ class TestStartStreamTransactionRequest:
             request.headers["x-amzn-transcribe-identify-multiple-languages"] == "True"
         )
         assert request.headers["x-amzn-transcribe-language-options"] == "en-US,de-DE"
-        assert (
-            request.headers["x-amzn-transcribe-vocabulary-names"]
-            == "EnglishVoc,GermanVoc"
-        )
+        cv_header = "x-amzn-transcribe-vocabulary-names"
+        assert request.headers[cv_header] == "EnglishVoc,GermanVoc"
 
 
 class TestAudioEventSerializer:

--- a/tests/functional/test_serialize.py
+++ b/tests/functional/test_serialize.py
@@ -70,7 +70,10 @@ class TestStartStreamTransactionRequest:
             request.headers["x-amzn-transcribe-identify-multiple-languages"] == "True"
         )
         assert request.headers["x-amzn-transcribe-language-options"] == "en-US,de-DE"
-        assert request.headers["x-amzn-transcribe-vocabulary-names"] == "EnglishVoc,GermanVoc"
+        assert (
+            request.headers["x-amzn-transcribe-vocabulary-names"]
+            == "EnglishVoc,GermanVoc"
+        )
 
 
 class TestAudioEventSerializer:

--- a/tests/functional/test_serialize.py
+++ b/tests/functional/test_serialize.py
@@ -28,6 +28,7 @@ def multi_lid_request():
         media_sample_rate_hz=9000,
         media_encoding="pcm",
         identify_multiple_languages=True,
+        vocabulary_names=["EnglishVoc", "GermanVoc"],
         language_options=["en-US", "de-DE"],
     )
 
@@ -69,6 +70,7 @@ class TestStartStreamTransactionRequest:
             request.headers["x-amzn-transcribe-identify-multiple-languages"] == "True"
         )
         assert request.headers["x-amzn-transcribe-language-options"] == "en-US,de-DE"
+        assert request.headers["x-amzn-transcribe-vocabulary-names"] == "EnglishVoc,GermanVoc"
 
 
 class TestAudioEventSerializer:

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -9,7 +9,11 @@ from amazon_transcribe.exceptions import (
 )
 from tests.integration import TEST_WAV_PATH
 
-
+request_options = [
+    {"language_code": "en-US", "media_sample_rate_hz": 16000, "media_encoding": "pcm"},
+    {"language_code": None, "media_sample_rate_hz": 16000, "media_encoding": "pcm",
+     "identify_multiple_languages": True, "language_options": ["en-US", "de-DE"]},
+]
 class TestClientStreaming:
     @pytest.fixture
     def client(self):
@@ -31,12 +35,9 @@ class TestClientStreaming:
         return byte_generator
 
     @pytest.mark.asyncio
-    async def test_client_start_transcribe_stream(self, client, wav_bytes):
-        stream = await client.start_stream_transcription(
-            language_code="en-US",
-            media_sample_rate_hz=16000,
-            media_encoding="pcm",
-        )
+    @pytest.mark.parametrize('request_args', request_options)
+    async def test_client_start_transcribe_stream(self, client, wav_bytes, request_args):
+        stream = await client.start_stream_transcription(**request_args)
 
         async for chunk in wav_bytes():
             await stream.input_stream.send_audio_event(audio_chunk=chunk)

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -10,10 +10,24 @@ from amazon_transcribe.exceptions import (
 from tests.integration import TEST_WAV_PATH
 
 request_options = [
-    {"language_code": "en-US", "media_sample_rate_hz": 16000, "media_encoding": "pcm"},
-    {"language_code": None, "media_sample_rate_hz": 16000, "media_encoding": "pcm",
-     "identify_multiple_languages": True, "language_options": ["en-US", "de-DE"]},
+    # plain request with a known language
+    {"language_code": "en-US"},
+    # language identification
+    {
+        "language_code": None,
+        "identify_language": True,
+        "language_options": ["en-US", "de-DE"],
+        "preferred_language": "en-US",
+    },
+    # multiple language identification
+    {
+        "language_code": None,
+        "identify_multiple_languages": True,
+        "language_options": ["en-US", "de-DE"],
+    },
 ]
+
+
 class TestClientStreaming:
     @pytest.fixture
     def client(self):
@@ -35,9 +49,13 @@ class TestClientStreaming:
         return byte_generator
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize('request_args', request_options)
-    async def test_client_start_transcribe_stream(self, client, wav_bytes, request_args):
-        stream = await client.start_stream_transcription(**request_args)
+    @pytest.mark.parametrize("request_args", request_options)
+    async def test_client_start_transcribe_stream(
+        self, client, wav_bytes, request_args
+    ):
+        stream = await client.start_stream_transcription(
+            media_sample_rate_hz=16000, media_encoding="pcm", **request_args
+        )
 
         async for chunk in wav_bytes():
             await stream.input_stream.send_audio_event(audio_chunk=chunk)

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -24,6 +24,7 @@ request_options = [
         "language_code": None,
         "identify_multiple_languages": True,
         "language_options": ["en-US", "de-DE"],
+        "vocab_filter_names": ["english", "german"],
     },
 ]
 

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -69,6 +69,8 @@ class TestClientStreaming:
             for result in results:
                 for alt in result.alternatives:
                     last_transcript = alt.transcript
+                if "identify_multiple_languages" in request_args:
+                    assert result.language_code in request_args["language_options"]
         # Assert that we got some words back as the service may change its response
         assert len(last_transcript.split(" ")) != 0
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Hi, Transcribe SDE here. We recently launched a new feature called [multiple language identification](https://docs.aws.amazon.com/transcribe/latest/dg/lang-id-stream.html#multi-language-streaming). We've been asked to contribute to this package to enable the feature so customers can use it.

*Notes*
`language_code` is currently a required positional parameter. When language ID is added, language code should become optional. That means we'd have to make it the third param and give it a default value, but this would break existing clients that use positional-only arguments. Therefore I'm leaving it as a positional arg and requiring that it's set to None when language ID is enabled. I'm not too happy with this option either- happy to discuss. Maybe something like this would be more ergonomic:

```
        if identify_language or identify_language:
            warnings.warm("Setting language_code to None because language ID is enabled")
            language_code = None
```


*Testing*
I extended and ran the integration tests locally from my own AWS account. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
