### PR TITLE
Serializing boolean headers to lower case syntax

### DIFF
--- a/amazon_transcribe/serialize.py
+++ b/amazon_transcribe/serialize.py
@@ -54,7 +54,10 @@ class TranscribeStreamingSerializer:
     def _serialize_bool_header(
         self, header: str, value: Optional[bool]
     ) -> Dict[str, str]:
-        return self._serialize_header(header, value)
+        if value:
+            return self._serialize_header(header, 'true')
+        else:
+            return self._serialize_header(header, 'false')
 
     def serialize_start_stream_transcription_request(
         self, endpoint: str, request_shape: StartStreamTranscriptionRequest


### PR DESCRIPTION
*Issue #, if available:* #63

*Description of changes:* Updated serialize.py to handle boolean headers as lower case rather than capitalized.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
